### PR TITLE
Modify the "func SetNewY, SetNewYIfNoOffset, SetNewXY" and discuss how to improve

### DIFF
--- a/gopdf.go
+++ b/gopdf.go
@@ -334,13 +334,14 @@ func (gp *GoPdf) GetX() float64 {
 // Because of called AddPage(), X is set to MarginLeft, so you should specify X if needed,
 // or make sure SetX() is after SetNewY(), or using SetNewXY().
 // SetNewYIfNoOffset is more suitable for scenarios where the offset does not change, such as pdf.Image().
-func (gp *GoPdf) SetNewY(y *float64, h float64) {
-	gp.UnitsToPointsVar(y)
+func (gp *GoPdf) SetNewY(y float64, h float64) {
+	gp.UnitsToPointsVar(&y)
+	gp.UnitsToPointsVar(&h)
 	if gp.curr.Y+h > gp.curr.pageSize.H-gp.MarginBottom() {
 		gp.AddPage()
-		*y = gp.MarginTop() // reset to top of the page.
+		y = gp.MarginTop() // reset to top of the page.
 	}
-	gp.curr.Y = *y
+	gp.curr.Y = y
 }
 
 //SetNewYIfNoOffset : set current position y, and modified y if add a new page.
@@ -349,13 +350,14 @@ func (gp *GoPdf) SetNewY(y *float64, h float64) {
 // MarginBottom is 10px, and the height of the element(such as image) to be inserted is 200px,
 // because 10<200, you need to add another page and set y to 20px.
 // Tips: gp.curr.X and gp.curr.Y do not change when pdf.Image() is called.
-func (gp *GoPdf) SetNewYIfNoOffset(y *float64, h float64) {
-	gp.UnitsToPointsVar(y)
-	if *y+h > gp.curr.pageSize.H-gp.MarginBottom() { // using new y(*y) instead of gp.curr.Y
+func (gp *GoPdf) SetNewYIfNoOffset(y float64, h float64) {
+	gp.UnitsToPointsVar(&y)
+	gp.UnitsToPointsVar(&h)
+	if y+h > gp.curr.pageSize.H-gp.MarginBottom() { // using new y(*y) instead of gp.curr.Y
 		gp.AddPage()
-		*y = gp.MarginTop() // reset to top of the page.
+		y = gp.MarginTop() // reset to top of the page.
 	}
-	gp.curr.Y = *y
+	gp.curr.Y = y
 }
 
 //SetNewXY : set current position x and y, and modified y if add a new page.
@@ -365,15 +367,55 @@ func (gp *GoPdf) SetNewYIfNoOffset(y *float64, h float64) {
 // because 10<25, you need to add another page and set y to 20px.
 // Because of AddPage(), X is set to MarginLeft, so you should specify X if needed,
 // or make sure SetX() is after SetNewY().
-func (gp *GoPdf) SetNewXY(y *float64, x, h float64) {
-	gp.UnitsToPointsVar(y)
+func (gp *GoPdf) SetNewXY(y float64, x, h float64) {
+	gp.UnitsToPointsVar(&y)
+	gp.UnitsToPointsVar(&h)
 	if gp.curr.Y+h > gp.curr.pageSize.H-gp.MarginBottom() {
 		gp.AddPage()
-		*y = gp.MarginTop() // reset to top of the page.
+		y = gp.MarginTop() // reset to top of the page.
 	}
-	gp.curr.X = x
-	gp.curr.Y = *y
+	gp.curr.Y = y
+	gp.SetX(x)
 }
+
+/*
+//experimental
+func (gp *GoPdf) SetNewY(y float64, h float64) float64 {
+	gp.UnitsToPointsVar(&y)
+	gp.UnitsToPointsVar(&h)
+	if gp.curr.Y+h > gp.curr.pageSize.H-gp.MarginBottom() {
+		gp.AddPage()
+		y = gp.MarginTop() // reset to top of the page.
+	}
+	gp.curr.Y = y
+	return gp.GetY()
+}
+
+//experimental
+func (gp *GoPdf) SetNewYIfNoOffset(y float64, h float64) float64 {
+	gp.UnitsToPointsVar(&y)
+	gp.UnitsToPointsVar(&h)
+	if y+h > gp.curr.pageSize.H-gp.MarginBottom() { // using new y(*y) instead of gp.curr.Y
+		gp.AddPage()
+		y = gp.MarginTop() // reset to top of the page.
+	}
+	gp.curr.Y = y
+	return gp.GetY()
+}
+
+//experimental
+func (gp *GoPdf) SetNewXY(y float64, x, h float64) float64{
+	gp.UnitsToPointsVar(&y)
+	gp.UnitsToPointsVar(&h)
+	if gp.curr.Y+h > gp.curr.pageSize.H-gp.MarginBottom() {
+		gp.AddPage()
+		y = gp.MarginTop() // reset to top of the page.
+	}
+	gp.curr.Y = y
+	gp.SetX(x)
+	return gp.GetY()
+}
+*/
 
 //SetY : set current position y
 func (gp *GoPdf) SetY(y float64) {

--- a/test/pagination/page_image_test.go
+++ b/test/pagination/page_image_test.go
@@ -2,10 +2,11 @@ package pagination
 
 import (
 	"fmt"
-	"github.com/signintech/gopdf"
 	"log"
 	"testing"
 	"time"
+
+	"github.com/signintech/gopdf"
 )
 
 func TestPageWithImage(t *testing.T) {
@@ -23,7 +24,8 @@ func TestPageWithImage(t *testing.T) {
 	}
 	for i := 0; i < 10; i++ {
 		var imgHeight float64 = 241 * 72 / 120
-		pdf.SetNewYIfNoOffset(&y, imgHeight)
+		pdf.SetNewYIfNoOffset(y, imgHeight)
+		y = pdf.GetY()
 		err = pdf.Image("../res/gopher01.jpg", x, y, imgRect)
 		if err != nil {
 			log.Fatal(err)

--- a/test/pagination/page_test.go
+++ b/test/pagination/page_test.go
@@ -2,11 +2,12 @@ package pagination
 
 import (
 	"fmt"
-	"github.com/signintech/gopdf"
 	"log"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/signintech/gopdf"
 )
 
 func GetFont(pdf *gopdf.GoPdf, fontPath string) (err error) {
@@ -77,7 +78,8 @@ func TestSetNewY(t *testing.T) {
 		text := fmt.Sprintf("---------line no: %d -----------", i)
 		var textH float64 = 25 // if text height is 25px.
 		pdf.SetX(x)
-		pdf.SetNewY(&y, textH)
+		pdf.SetNewY(y, textH)
+		y = pdf.GetY()
 		err = pdf.Text(text)
 		if err != nil {
 			log.Fatalln(err)
@@ -112,7 +114,8 @@ func TestSetNewXY(t *testing.T) {
 		text := fmt.Sprintf("---------line no: %d -----------", i)
 		var textH float64 = 25 // if text height is 25px.
 		//pdf.SetX(x)
-		pdf.SetNewXY(&y, x, textH)
+		pdf.SetNewXY(y, x, textH)
+		y = pdf.GetY()
 		err = pdf.Text(text)
 		if err != nil {
 			log.Fatalln(err)
@@ -146,7 +149,8 @@ func TestSetNewYX(t *testing.T) {
 	for i := 0; i < 200; i++ {
 		text := fmt.Sprintf("---------line no: %d -----------", i)
 		var textH float64 = 25 // if text height is 25px.
-		pdf.SetNewY(&y, textH)
+		pdf.SetNewY(y, textH)
+		y = pdf.GetY()
 		pdf.SetX(x) // must after pdf.SetNewY() called.
 		err = pdf.Text(text)
 		if err != nil {
@@ -158,5 +162,33 @@ func TestSetNewYX(t *testing.T) {
 	err = pdf.WritePdf(fmt.Sprintf("page_setnewyx-%s.pdf", time.Now().Format("01-02-15-04-05")))
 	if err != nil {
 		log.Fatalln(err)
+	}
+}
+
+func TestSetNewYCheckHeight(t *testing.T) {
+	var err error
+	pdf := &gopdf.GoPdf{}
+	pdf.Start(gopdf.Config{PageSize: *gopdf.PageSizeA4})
+	err = GetFont(pdf, "../res/LiberationSerif-Regular.ttf")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	err = pdf.SetFont("Ubuntu-L", "", 14)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	pdf.SetMargins(0, 20, 0, 10)
+	pdf.AddPage()
+
+	y := 10.0
+	pdf.SetNewY(y, 0)
+	if y != pdf.GetY() {
+		log.Fatalln(" y != pdf.GetY()")
+	}
+
+	y = 1000.0
+	pdf.SetNewY(y, 0)
+	if y != pdf.GetY() {
+		log.Fatalln(" y != pdf.GetY()")
 	}
 }


### PR DESCRIPTION
I changed function SetNewY to take value of y (instead of pointer of y) and used function GetY() to take the value of y instead.
```GO
y := 10.0
pdf.SetNewY(y, textH)
y = pdf.GetY()
```

Another idea is that the func SetNewY returns a new y value.
(if this function return new Y maybe this function no longer suitable for name "SetNewY". But I still can't figure out what it should be called. )
```GO
func (gp *GoPdf) SetNewY(y float64, h float64) float64 {
	gp.UnitsToPointsVar(&y)
	gp.UnitsToPointsVar(&h)
	if gp.curr.Y+h > gp.curr.pageSize.H-gp.MarginBottom() {
		gp.AddPage()
		y = gp.MarginTop() // reset to top of the page.
	}
	gp.curr.Y = y
	return gp.GetY()
}
```